### PR TITLE
fix(version): mysqld_exporter updated to `0.16.0` release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # See available releases: https://github.com/prometheus/mysqld_exporter/releases
-mysqld_exporter_version: '0.15.1'
+mysqld_exporter_version: '0.16.0'
 mysqld_exporter_archive_name: 'mysqld_exporter-{{ mysqld_exporter_version }}.linux-{{ __mysqld_exporter_architecture }}'
 mysqld_exporter_download_url: 'https://github.com/prometheus/mysqld_exporter/releases/download/v{{ mysqld_exporter_version }}'
 mysqld_exporter_checksum_url: '{{ mysqld_exporter_download_url }}/sha256sums.txt'

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -9,7 +9,7 @@ argument_specs:
       mysqld_exporter_version:
         type: 'str'
         description: 'The version of MySQLd Exporter to install.'
-        default: '0.15.1'
+        default: '0.16.0'
       mysqld_exporter_archive_name:
         type: 'str'
         description: 'The MySQLd Exporter archive name without an extension.'


### PR DESCRIPTION
The upstream [mysqld_exporter](https://github.com/prometheus/mysqld_exporter/releases) released new software version - **0.16.0**!

This automated PR updates code to bring new version into repository.